### PR TITLE
Fix README.md installation; Add virtual env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 *.iml
 .vscode
 /.idea/
+.venv

--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ GET
 
 ## Installation
 
+
 ```console
-$ python3.7 -m pip install connexion Flask pytest
+$ python3.7 -m pip install "connexion[swagger-ui]" Flask pytest
 ```
 
 ## Test


### PR DESCRIPTION
Running the README.md instructions fails to load the swagger UI. This will resolve that. 